### PR TITLE
Fix dictionary key escaping to maintain proper backslash escaping

### DIFF
--- a/Sources/Spanker/Spanker.swift
+++ b/Sources/Spanker/Spanker.swift
@@ -1048,7 +1048,8 @@ public final class JsonElement: CustomStringConvertible, Equatable {
             for idx in 0..<keyArray.count {
                 nextLine(offset: 1)
                 hitch.append(.doubleQuote)
-                hitch.append(keyArray[idx])
+                // Key needs to be escaped for JSON
+                hitch.append(keyArray[idx].escaped(unicode: false, singleQuotes: false))
                 hitch.append(.doubleQuote)
                 hitch.append(.colon)
                 if pretty {

--- a/Tests/SpankerTests/Tests.swift
+++ b/Tests/SpankerTests/Tests.swift
@@ -747,7 +747,26 @@ class SpankerTests: TestsBase {
         XCTAssertEqual(jsonA.toHitch(), #"[1,2,4,5]"#)
     }
 
-    
+    func test_key_escaping_in_dictionary() {
+        // Test dictionary with escaped backslash in key
+        let dict: JsonElementableDictionary = [
+            "U>\\{": "value1",  // Key with backslash that needs escaping
+            "normal": "value2"   // Normal key for comparison
+        ]
+
+        let element = dict.toJsonElement()
+        let jsonString = element.toHitch().toString()
+
+        // The key should be properly escaped in the output JSON
+        XCTAssertTrue(jsonString.contains("\"U>\\\\{\""))
+
+        // Verify we can parse it back
+        jsonString.parsed { result in
+            XCTAssertEqual(result?[string: "U>\\{"], "value1")
+            XCTAssertEqual(result?[string: "normal"], "value2")
+        }
+    }
+
 }
 
 


### PR DESCRIPTION
# Fix JSON dictionary key escaping

Fixes an issue where dictionary keys containing backslashes were not properly escaped during JSON serialization. This affected both keys containing backslashes and keys ending with backslashes.

## The Issue #3 
When serializing dictionaries to JSON, keys containing backslashes were being written directly without proper JSON escaping. This led to:
1. Invalid JSON when keys contained backslashes (`"U>\{"` instead of `"U>\\{"`)
2. Completely broken JSON structure when keys ended with backslashes

Before:
```
{
  "U>\{": "value",
  "Dgf":{": "broken json"
}
```

After:

```
{
  "U>\\{": "value",
  "Dgf\\": "proper json"
}
```

## The Fix
Modified JsonElement's `exportTo` to properly escape dictionary keys during JSON serialization by applying the same escaping rules used for string values to dictionary keys. This ensures all backslashes are properly escaped according to JSON spec.

This ensures proper JSON output that can be reliably parsed by standard JSON parsers.

## Notes
- Added a test case for this.
- `test_large_load()` was already failing, all other tests pass, this addition doesn't break any existing tests.